### PR TITLE
Add a catch for the describe_account boto3 api throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.3.1] - 2021-27-9
+### Fixed
+- Fixed bug where a large amount of accounts would cause the AWS DescribeAccount api to throttle and throw an exception
 ## [1.3.0] - 2021-07-1
 ### Added
 - Added option to set a custom `RoleSessionName` parameter in `sts.assume_role()` calls for the `cove` decorator.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "botocove"
-version = "1.3.0"
+version = "1.3.1"
 description = "A decorator to allow running a function against all AWS accounts in an organization"
 authors = ["Dave Connell <daveconn41@gmail.com>"]
 license = "LGPL-3.0-or-later"


### PR DESCRIPTION
Quick and dirty fix for #12 for now - I have some ideas about a bit of a re-write while not changing the end user API that could implement some sort of queue to feed into the async loop that could also track boto3 starting to rate limit us and back off/retry.