### PR TITLE
Allow setting session policy of assumed role

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ organization, assume the `OrganizationAccountAccessRole` in it and run the
 wrapped function with that role.
 
 Equivalent to:
-`@cove(target_ids=None, ignore_ids=None, rolename=None, assuming_session=None, 
-    raise_exception=False, org_master=True)`
+`@cove(target_ids=None, ignore_ids=None, rolename=None, role_session_name=rolename,
+    policy=None, policy_arns=None, assuming_session=None, raise_exception=False,
+    org_master=True)`
 
 `target_ids`: Optional[List[str]]
 
@@ -125,6 +126,14 @@ Defaults to the AWS Organization default, `OrganizationAccountAccessRole`.
 
 An IAM role session name that will be passed to each Cove session's `sts.assume_role()` call. 
 Defaults to the name of the role being used if unset.
+
+`policy`: Optional[str]
+
+A policy document that will be used as a session policy in each Cove session's `sts.assume_role()` call. Unless the value is None, it is passed through via the Policy parameter.
+
+`policy_arns`: Optional[List[PolicyArn]]
+
+A list of managed policy ARNs that will be used as a session policy in each Cove session's `sts.assume_role()` call. Unless the value is None, it is passed through via the PolicyArns parameter.
 
 `assuming_session`: Optional[Session]
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Defaults to the name of the role being used if unset.
 
 A policy document that will be used as a session policy in each Cove session's `sts.assume_role()` call. Unless the value is None, it is passed through via the Policy parameter.
 
-`policy_arns`: Optional[List[PolicyArn]]
+`policy_arns`: Optional[List[str]]
 
 A list of managed policy ARNs that will be used as a session policy in each Cove session's `sts.assume_role()` call. Unless the value is None, it is passed through via the PolicyArns parameter.
 

--- a/botocove/cove_decorator.py
+++ b/botocove/cove_decorator.py
@@ -24,6 +24,7 @@ def cove(
     ignore_ids: Optional[List[str]] = None,
     rolename: Optional[str] = None,
     role_session_name: Optional[str] = None,
+    policy: Optional[str] = None,
     assuming_session: Optional[Session] = None,
     raise_exception: bool = False,
     org_master: bool = True,
@@ -36,6 +37,7 @@ def cove(
                 ignore_ids=ignore_ids,
                 rolename=rolename,
                 role_session_name=role_session_name,
+                policy=policy,
                 org_master=org_master,
                 assuming_session=assuming_session,
             ).get_cove_sessions()

--- a/botocove/cove_decorator.py
+++ b/botocove/cove_decorator.py
@@ -7,7 +7,7 @@ from boto3.session import Session
 
 from botocove.cove_runner import CoveRunner
 from botocove.cove_sessions import CoveSessions
-from botocove.cove_types import CoveOutput, CoveSessionInformation, R
+from botocove.cove_types import CoveOutput, CoveSessionInformation, PolicyArn, R
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +25,7 @@ def cove(
     rolename: Optional[str] = None,
     role_session_name: Optional[str] = None,
     policy: Optional[str] = None,
+    policy_arns: Optional[List[PolicyArn]] = None,
     assuming_session: Optional[Session] = None,
     raise_exception: bool = False,
     org_master: bool = True,
@@ -38,6 +39,7 @@ def cove(
                 rolename=rolename,
                 role_session_name=role_session_name,
                 policy=policy,
+                policy_arns=policy_arns,
                 org_master=org_master,
                 assuming_session=assuming_session,
             ).get_cove_sessions()

--- a/botocove/cove_decorator.py
+++ b/botocove/cove_decorator.py
@@ -7,7 +7,7 @@ from boto3.session import Session
 
 from botocove.cove_runner import CoveRunner
 from botocove.cove_sessions import CoveSessions
-from botocove.cove_types import CoveOutput, CoveSessionInformation, PolicyArn, R
+from botocove.cove_types import CoveOutput, CoveSessionInformation, R
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ def cove(
     rolename: Optional[str] = None,
     role_session_name: Optional[str] = None,
     policy: Optional[str] = None,
-    policy_arns: Optional[List[PolicyArn]] = None,
+    policy_arns: Optional[List[str]] = None,
     assuming_session: Optional[Session] = None,
     raise_exception: bool = False,
     org_master: bool = True,

--- a/botocove/cove_sessions.py
+++ b/botocove/cove_sessions.py
@@ -12,7 +12,7 @@ from mypy_boto3_sts.client import STSClient
 from tqdm import tqdm
 
 from botocove.cove_session import CoveSession
-from botocove.cove_types import CoveResults, CoveSessionInformation, PolicyArn
+from botocove.cove_types import CoveResults, CoveSessionInformation
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class CoveSessions(object):
         rolename: Optional[str],
         role_session_name: Optional[str],
         policy: Optional[str],
-        policy_arns: Optional[List[PolicyArn]],
+        policy_arns: Optional[List[str]],
         assuming_session: Optional[Session],
         org_master: bool,
     ) -> None:
@@ -104,6 +104,7 @@ class CoveSessions(object):
             logger.debug(f"Attempting to assume {role_arn}")
             # This calling style avoids a ParamValidationError from botocore.
             # Passing None is not allowed for the optional parameters.
+
             assume_role_args = {
                 k: v
                 for k, v in [
@@ -114,7 +115,7 @@ class CoveSessions(object):
                 ]
                 if v is not None
             }
-            creds = self.sts_client.assume_role(**assume_role_args)["Credentials"]
+            creds = self.sts_client.assume_role(**assume_role_args)["Credentials"]  # type: ignore[arg-type] # noqa E501
             cove_session.initialize_boto_session(
                 aws_access_key_id=creds["AccessKeyId"],
                 aws_secret_access_key=creds["SecretAccessKey"],

--- a/botocove/cove_types.py
+++ b/botocove/cove_types.py
@@ -6,10 +6,6 @@ from mypy_boto3_organizations.literals import AccountStatusType
 R = TypeVar("R")
 
 
-class PolicyArn(TypedDict):
-    arn: str
-
-
 @dataclass
 class CoveSessionInformation(Generic[R]):
     Id: str
@@ -20,7 +16,7 @@ class CoveSessionInformation(Generic[R]):
     AssumeRoleSuccess: Optional[bool] = None
     RoleSessionName: Optional[str] = None
     Policy: Optional[str] = None
-    PolicyArns: Optional[List[PolicyArn]] = None
+    PolicyArns: Optional[List[str]] = None
     Result: Optional[R] = None
     ExceptionDetails: Optional[Exception] = None
 

--- a/botocove/cove_types.py
+++ b/botocove/cove_types.py
@@ -15,6 +15,7 @@ class CoveSessionInformation(Generic[R]):
     Status: Optional[AccountStatusType] = None
     AssumeRoleSuccess: Optional[bool] = None
     RoleSessionName: Optional[str] = None
+    Policy: Optional[str] = None
     Result: Optional[R] = None
     ExceptionDetails: Optional[Exception] = None
 

--- a/botocove/cove_types.py
+++ b/botocove/cove_types.py
@@ -6,6 +6,10 @@ from mypy_boto3_organizations.literals import AccountStatusType
 R = TypeVar("R")
 
 
+class PolicyArn(TypedDict):
+    arn: str
+
+
 @dataclass
 class CoveSessionInformation(Generic[R]):
     Id: str
@@ -16,6 +20,7 @@ class CoveSessionInformation(Generic[R]):
     AssumeRoleSuccess: Optional[bool] = None
     RoleSessionName: Optional[str] = None
     Policy: Optional[str] = None
+    PolicyArns: Optional[List[PolicyArn]] = None
     Result: Optional[R] = None
     ExceptionDetails: Optional[Exception] = None
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -173,10 +173,11 @@ def test_decorated_simple_func_passed_policy(mock_boto3_session) -> None:
         org_master=False,
     )
     def simple_func(session):
-        return session.session_information["Policy"]
+        return session.session_information.Policy
 
     cove_output = simple_func()
 
+    assert cove_output["Exceptions"] == []
     assert all(x["Result"] == session_policy for x in cove_output["Results"])
 
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -162,3 +162,19 @@ def test_decorated_simple_func_passed_session_name(
     cove_output = simple_func()
     print(cove_output)
     assert all(x["Result"] == session_name for x in cove_output["Results"])
+
+
+def test_decorated_simple_func_passed_policy(mock_boto3_session) -> None:
+    session_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"*","Resource":"*"}]}'  # noqa: E501
+
+    @cove(
+        assuming_session=mock_boto3_session,
+        policy=session_policy,
+        org_master=False,
+    )
+    def simple_func(session):
+        return session.session_information["Policy"]
+
+    cove_output = simple_func()
+
+    assert all(x["Result"] == session_policy for x in cove_output["Results"])

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -178,3 +178,20 @@ def test_decorated_simple_func_passed_policy(mock_boto3_session) -> None:
     cove_output = simple_func()
 
     assert all(x["Result"] == session_policy for x in cove_output["Results"])
+
+
+def test_decorated_simple_func_passed_policy_arn(mock_boto3_session) -> None:
+    session_policy_arns = [{"arn": "arn:aws:iam::aws:policy/IAMReadOnlyAccess"}]
+
+    @cove(
+        assuming_session=mock_boto3_session,
+        policy_arns=session_policy_arns,
+        org_master=False,
+    )
+    def simple_func(session):
+        return session.session_information.PolicyArns
+
+    cove_output = simple_func()
+
+    assert cove_output["Exceptions"] == []
+    assert all(x["Result"] == session_policy_arns for x in cove_output["Results"])

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -160,7 +160,8 @@ def test_decorated_simple_func_passed_session_name(
         return session.session_information.RoleSessionName
 
     cove_output = simple_func()
-    print(cove_output)
+
+    assert cove_output["Exceptions"] == []
     assert all(x["Result"] == session_name for x in cove_output["Results"])
 
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -165,7 +165,7 @@ def test_decorated_simple_func_passed_session_name(
     assert all(x["Result"] == session_name for x in cove_output["Results"])
 
 
-def test_decorated_simple_func_passed_policy(mock_boto3_session) -> None:
+def test_decorated_simple_func_passed_policy(mock_boto3_session: MagicMock) -> None:
     session_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"*","Resource":"*"}]}'  # noqa: E501
 
     @cove(
@@ -173,7 +173,7 @@ def test_decorated_simple_func_passed_policy(mock_boto3_session) -> None:
         policy=session_policy,
         org_master=False,
     )
-    def simple_func(session):
+    def simple_func(session: CoveSession) -> Optional[str]:
         return session.session_information.Policy
 
     cove_output = simple_func()
@@ -182,15 +182,15 @@ def test_decorated_simple_func_passed_policy(mock_boto3_session) -> None:
     assert all(x["Result"] == session_policy for x in cove_output["Results"])
 
 
-def test_decorated_simple_func_passed_policy_arn(mock_boto3_session) -> None:
-    session_policy_arns = [{"arn": "arn:aws:iam::aws:policy/IAMReadOnlyAccess"}]
+def test_decorated_simple_func_passed_policy_arn(mock_boto3_session: MagicMock) -> None:
+    session_policy_arns = ["arn:aws:iam::aws:policy/IAMReadOnlyAccess"]
 
     @cove(
         assuming_session=mock_boto3_session,
         policy_arns=session_policy_arns,
         org_master=False,
     )
-    def simple_func(session):
+    def simple_func(session: CoveSession) -> Optional[List[str]]:
         return session.session_information.PolicyArns
 
     cove_output = simple_func()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -54,6 +54,31 @@ def test_session_result_formatter(patch_boto3_client: MagicMock) -> None:
     assert cove_output["Results"] == expected
 
 
+def test_session_result_formatter_with_policy(patch_boto3_client: MagicMock) -> None:
+    session_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"*","Resource":"*"}]}'  # noqa: E501
+
+    @cove(policy=session_policy)
+    def simple_func(session: CoveSession, a_string: str) -> str:
+        return a_string
+
+    # Only one account for simplicity
+    cove_output = simple_func("test-string")
+    expected = [
+        {
+            "Id": "12345689012",
+            "Arn": "hello-arn",
+            "Email": "email@address.com",
+            "Name": "an-account-name",
+            "Status": "ACTIVE",
+            "AssumeRoleSuccess": True,
+            "Result": "test-string",
+            "RoleSessionName": "OrganizationAccountAccessRole",
+            "Policy": session_policy,
+        }
+    ]
+    assert cove_output["Results"] == expected
+
+
 def test_session_result_error_handler(patch_boto3_client: MagicMock) -> None:
     # Raise an exception instead of an expected response from boto3
     patch_boto3_client.client.return_value.describe_account.side_effect = MagicMock(
@@ -62,7 +87,7 @@ def test_session_result_error_handler(patch_boto3_client: MagicMock) -> None:
         )
     )
 
-    @cove
+    @cove()
     def simple_func(session: CoveSession, a_string: str) -> str:
         return a_string
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -82,7 +82,7 @@ def test_session_result_formatter_with_policy(patch_boto3_client: MagicMock) -> 
 def test_session_result_formatter_with_policy_arn(
     patch_boto3_client: MagicMock,
 ) -> None:
-    session_policy_arns = [{"arn": "arn:aws:iam::aws:policy/IAMReadOnlyAccess"}]
+    session_policy_arns = ["arn:aws:iam::aws:policy/IAMReadOnlyAccess"]
 
     @cove(policy_arns=session_policy_arns)
     def simple_func(session: CoveSession, a_string: str) -> str:


### PR DESCRIPTION
A rewrite of #15 to adapt to the changes in v1.4.0 (#19).

Solves #14.

Still needs support for managed policy ARNs.