### PR TITLE
Make botocove easier to demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ def main():
 
     # A list of dictionaries for each account that could not be assumed into
     pprint(all_results["FailedAssumeRole"])
+
+
+if __name__ == "__main__":
+    main()
 ```
 
 Here's an example of a more customised Cove decorator:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In the organization master account:
 
 In the organization accounts:
 
-- An `AccountOrganizationAccessRole` role
+- An `OrganizationAccountAccessRole` role
 
 See the [arguments](#arguments) section for how to change these defaults to work
 with any account configuration, including running without an AWS Organization.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ In the organization master account:
 - IAM permissions `sts:assumerole`, `sts:get-caller-identity` and
 `organizations:list-accounts`
 
-In the organization accounts:
+In the organization member accounts:
 
-- An `OrganizationAccountAccessRole` role
+- An
+  [`OrganizationAccountAccessRole` role](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_access.html)
 
 See the [arguments](#arguments) section for how to change these defaults to work
 with any account configuration, including running without an AWS Organization.
@@ -81,6 +82,7 @@ Now with `@cove`: a session for every account in the organization is injected
 by the decorator. A safe example to run as a test!
 
 ```python
+from pprint import pprint
 import boto3
 from botocove import cove
 
@@ -97,13 +99,13 @@ def main():
 
     # A list of dictionaries for each account, with account details included.
     # Each account's get_iam_users return is in a "Result" key.
-    print(all_results["Results"])
+    pprint(all_results["Results"])
 
     # A list of dictionaries for each account that raised an exception
-    print(all_results["Exceptions"])
+    pprint(all_results["Exceptions"])
 
     # A list of dictionaries for each account that could not be assumed into
-    print(all_results["FailedAssumeRole"])
+    pprint(all_results["FailedAssumeRole"])
 ```
 
 Here's an example of a more customised Cove decorator:


### PR DESCRIPTION
To demo botocove I do the following:

* Create a new temporary Python virtualenv
* Install botocove with pip
* Copy and paste the demo code into `cove_demo.py`
* Set the `AWS_PROFILE` environment variable to my management account's profile
* Run `python cove_demo.py`

Previous to these changes, the above steps would produce no output because the demo script doesn't call `main`. You could call `main` in the interpreter instead using `python -i` instead, but it takes a bit more thinking.

Use `pprint` instead of `print` to make the output readable. Without it, you just get a wall of text which makes it hard to explain what just happened.
