### PR TITLE
Use moto org for all unit tests 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: "^docs/gitbook/"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0 # Use the ref you want to point at
+    rev: v4.1.0
     hooks:
       - id: trailing-whitespace
       - id: check-ast
@@ -21,13 +21,13 @@ repos:
         name: isort (python)
 
   - repo: https://github.com/ambv/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3.8
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.7.0
+    rev: v1.9.0
     hooks:
       - id: python-use-type-annotations
       - id: python-no-eval
@@ -55,4 +55,3 @@ repos:
         entry: poetry run mypy .
         language: system
         pass_filenames: false
-

--- a/README.md
+++ b/README.md
@@ -174,15 +174,15 @@ An IAM role session name that will be passed to each Cove session's
 
 `policy`: str
 
-A policy document that will be used as a session policy in each Cove session's
-`sts.assume_role()` call. Unless the value is None, it is passed through via the
-Policy parameter.
+A policy document that will be used as a session policy. A non-None value is
+passed through via the Policy parameter in each Cove session's
+`sts.assume_role()` call.
 
 `policy_arns`: List[[PolicyDescriptorTypeTypeDef](https://pypi.org/project/mypy-boto3-sts/)]
 
-A list of managed policy ARNs that will be used as a session policy in each Cove
-session's `sts.assume_role()` call. Unless the value is None, it is passed
-through via the PolicyArns parameter.
+A list of managed policy ARNs that will be used as a session policy. A non-None
+value is passed through via the PolicyArns parameter in each Cove session's
+`sts.assume_role()` call.
 
 `assuming_session`: Session
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ A policy document that will be used as a session policy in each Cove session's
 `sts.assume_role()` call. Unless the value is None, it is passed through via the
 Policy parameter.
 
-`policy_arns`: List[str]
+`policy_arns`: List[[PolicyDescriptorTypeTypeDef](https://pypi.org/project/mypy-boto3-sts/)]
 
 A list of managed policy ARNs that will be used as a session policy in each Cove
 session's `sts.assume_role()` call. Unless the value is None, it is passed

--- a/botocove/cove_decorator.py
+++ b/botocove/cove_decorator.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, Callable, List, Optional
 
 from boto3.session import Session
+from mypy_boto3_sts.type_defs import PolicyDescriptorTypeTypeDef
 
 from botocove.cove_host_account import CoveHostAccount
 from botocove.cove_runner import CoveRunner
@@ -19,7 +20,7 @@ def cove(
     rolename: Optional[str] = None,
     role_session_name: Optional[str] = None,
     policy: Optional[str] = None,
-    policy_arns: Optional[List[str]] = None,
+    policy_arns: Optional[List[PolicyDescriptorTypeTypeDef]] = None,
     assuming_session: Optional[Session] = None,
     raise_exception: bool = False,
     org_master: bool = True,

--- a/botocove/cove_host_account.py
+++ b/botocove/cove_host_account.py
@@ -20,6 +20,7 @@ from botocore.config import Config
 from mypy_boto3_organizations.client import OrganizationsClient
 from mypy_boto3_organizations.type_defs import ListChildrenResponseTypeDef
 from mypy_boto3_sts.client import STSClient
+from mypy_boto3_sts.type_defs import PolicyDescriptorTypeTypeDef
 
 from botocove.cove_types import CoveSessionInformation
 
@@ -39,7 +40,7 @@ class CoveHostAccount(object):
         rolename: Optional[str],
         role_session_name: Optional[str],
         policy: Optional[str],
-        policy_arns: Optional[List[str]],
+        policy_arns: Optional[List[PolicyDescriptorTypeTypeDef]],
         assuming_session: Optional[Session],
         org_master: bool,
         thread_workers: int,

--- a/botocove/cove_types.py
+++ b/botocove/cove_types.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, TypedDict
 
 from mypy_boto3_organizations.literals import AccountStatusType
+from mypy_boto3_sts.type_defs import PolicyDescriptorTypeTypeDef
 
 
 class CoveSessionInformation(TypedDict):
@@ -13,7 +14,7 @@ class CoveSessionInformation(TypedDict):
     Status: Optional[AccountStatusType]
     RoleSessionName: Optional[str]
     Policy: Optional[str]
-    PolicyArns: Optional[List[str]]
+    PolicyArns: Optional[List[PolicyDescriptorTypeTypeDef]]
     Result: Any
     ExceptionDetails: Optional[Exception]
     Region: Optional[str]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,18 +1,10 @@
-from typing import Iterable, List, Optional
+from typing import List, Optional
 
 import pytest
 from boto3 import Session
-from moto import mock_organizations, mock_sts
 from mypy_boto3_organizations.type_defs import AccountTypeDef
 
 from botocove import CoveSession, cove
-
-
-@pytest.fixture()
-def mock_session() -> Iterable[Session]:
-    """Returns a session with mock AWS services."""
-    with mock_sts(), mock_organizations():
-        yield Session()
 
 
 @pytest.fixture()

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -19,8 +19,9 @@ def org_accounts(mock_session: Session) -> List[AccountTypeDef]:
     return org.list_accounts()["Accounts"]
 
 
-@pytest.mark.usefixtures("org_accounts")
-def test_decorated_simple_func(mock_session: Session) -> None:
+def test_decorated_simple_func(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
     @cove(assuming_session=mock_session)
     def simple_func(session: CoveSession) -> str:
         return "hello"
@@ -90,8 +91,9 @@ def test_decorated_simple_func_passed_args(
     assert cove_output["Results"] == expected
 
 
-@pytest.mark.usefixtures("org_accounts")
-def test_decorated_simple_func_passed_session_name(mock_session: Session) -> None:
+def test_decorated_simple_func_passed_session_name(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
     session_name = "testSessionName"
 
     @cove(
@@ -108,8 +110,9 @@ def test_decorated_simple_func_passed_session_name(mock_session: Session) -> Non
     assert all(x["Result"] == session_name for x in cove_output["Results"])
 
 
-@pytest.mark.usefixtures("org_accounts")
-def test_decorated_simple_func_passed_policy(mock_session: Session) -> None:
+def test_decorated_simple_func_passed_policy(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
     session_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"*","Resource":"*"}]}'  # noqa: E501
 
     @cove(
@@ -126,8 +129,9 @@ def test_decorated_simple_func_passed_policy(mock_session: Session) -> None:
     assert all(x["Result"] == session_policy for x in cove_output["Results"])
 
 
-@pytest.mark.usefixtures("org_accounts")
-def test_decorated_simple_func_passed_policy_arn(mock_session: Session) -> None:
+def test_decorated_simple_func_passed_policy_arn(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
     session_policy_arns: List[PolicyDescriptorTypeTypeDef] = [
         {"arn": "arn:aws:iam::aws:policy/IAMReadOnlyAccess"}
     ]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 import pytest
 from boto3 import Session
 from mypy_boto3_organizations.type_defs import AccountTypeDef
+from mypy_boto3_sts.type_defs import PolicyDescriptorTypeTypeDef
 
 from botocove import CoveSession, cove
 
@@ -127,14 +128,18 @@ def test_decorated_simple_func_passed_policy(mock_session: Session) -> None:
 
 @pytest.mark.usefixtures("org_accounts")
 def test_decorated_simple_func_passed_policy_arn(mock_session: Session) -> None:
-    session_policy_arns = ["arn:aws:iam::aws:policy/IAMReadOnlyAccess"]
+    session_policy_arns: List[PolicyDescriptorTypeTypeDef] = [
+        {"arn": "arn:aws:iam::aws:policy/IAMReadOnlyAccess"}
+    ]
 
     @cove(
         assuming_session=mock_session,
         policy_arns=session_policy_arns,
         org_master=False,
     )
-    def simple_func(session: CoveSession) -> Optional[List[str]]:
+    def simple_func(
+        session: CoveSession,
+    ) -> Optional[List[PolicyDescriptorTypeTypeDef]]:
         return session.session_information["PolicyArns"]
 
     cove_output = simple_func()

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,56 +1,34 @@
-from datetime import datetime
-from typing import List, Optional
-from unittest.mock import MagicMock
+from typing import Iterable, List, Optional
 
 import pytest
+from boto3 import Session
+from moto import mock_organizations, mock_sts
+from mypy_boto3_organizations.type_defs import AccountTypeDef
 
 from botocove import CoveSession, cove
 
 
 @pytest.fixture()
-def mock_boto3_session() -> MagicMock:
-    mock_session = MagicMock()
-    list_accounts_result = {
-        "Accounts": [
-            {"Id": "123123123123", "Status": "ACTIVE"},
-            {"Id": "456456456456", "Status": "ACTIVE"},
-        ]
-    }
-    mock_session.client.return_value.get_paginator.return_value.paginate.return_value.build_full_result.return_value = (  # noqa E501
-        list_accounts_result
-    )
-    describe_account_results = [
-        {
-            "Account": {
-                "Id": "123123123123",
-                "Arn": "hello-arn",
-                "Email": "email@address.com",
-                "Name": "an-account-name",
-                "Status": "ACTIVE",
-                "JoinedMethod": "CREATED",
-                "JoinedTimestamp": datetime(2015, 1, 1),
-            }
-        },
-        {
-            "Account": {
-                "Id": "456456456456",
-                "Arn": "hello-arn",
-                "Email": "email@address.com",
-                "Name": "an-account-name",
-                "Status": "ACTIVE",
-                "JoinedMethod": "CREATED",
-                "JoinedTimestamp": datetime(2015, 1, 1),
-            }
-        },
-    ]
-    mock_session.client.return_value.describe_account.side_effect = (
-        describe_account_results
-    )
-    return mock_session
+def mock_session() -> Iterable[Session]:
+    """Returns a session with mock AWS services."""
+    with mock_sts(), mock_organizations():
+        yield Session()
 
 
-def test_decorated_simple_func(mock_boto3_session: MagicMock) -> None:
-    @cove(assuming_session=mock_boto3_session)
+@pytest.fixture()
+def org_accounts(mock_session: Session) -> List[AccountTypeDef]:
+    """Returns a list of the accounts in the mock org. Index 0 is the management
+    account."""
+    org = mock_session.client("organizations")
+    org.create_organization(FeatureSet="ALL")
+    org.create_account(Email="email@address.com", AccountName="an-account-name")
+    org.create_account(Email="email@address.com", AccountName="an-account-name")
+    return org.list_accounts()["Accounts"]
+
+
+@pytest.mark.usefixtures("org_accounts")
+def test_decorated_simple_func(mock_session: Session) -> None:
+    @cove(assuming_session=mock_session)
     def simple_func(session: CoveSession) -> str:
         return "hello"
 
@@ -59,11 +37,13 @@ def test_decorated_simple_func(mock_boto3_session: MagicMock) -> None:
     assert len(cove_output["Results"]) == 2
 
 
-def test_target_and_ignore_ids(mock_boto3_session: MagicMock) -> None:
+def test_target_and_ignore_ids(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
     @cove(
-        assuming_session=mock_boto3_session,
-        target_ids=["123123123123", "456456456456"],
-        ignore_ids=["456456456456"],
+        assuming_session=mock_session,
+        target_ids=[org_accounts[1]["Id"], org_accounts[2]["Id"]],
+        ignore_ids=[org_accounts[2]["Id"]],
     )
     def simple_func(session: CoveSession) -> str:
         return "hello"
@@ -74,10 +54,12 @@ def test_target_and_ignore_ids(mock_boto3_session: MagicMock) -> None:
     assert len(cove_output["Results"]) == 1
 
 
-def test_empty_ignore_ids(mock_boto3_session: MagicMock) -> None:
+def test_empty_ignore_ids(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
     @cove(
-        assuming_session=mock_boto3_session,
-        target_ids=["123123123123", "456456456456"],
+        assuming_session=mock_session,
+        target_ids=[org_accounts[1]["Id"], org_accounts[2]["Id"]],
         ignore_ids=[],
     )
     def simple_func(session: CoveSession) -> str:
@@ -90,18 +72,20 @@ def test_empty_ignore_ids(mock_boto3_session: MagicMock) -> None:
     assert len(cove_output["Results"]) == 2
 
 
-def test_decorated_simple_func_passed_args(mock_boto3_session: MagicMock) -> None:
-    @cove(assuming_session=mock_boto3_session, ignore_ids=["456456456456"])
+def test_decorated_simple_func_passed_args(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
+    @cove(assuming_session=mock_session, ignore_ids=[org_accounts[2]["Id"]])
     def simple_func(session: CoveSession, arg1: int, arg2: int, arg3: int) -> int:
         return arg1 + arg2 + arg3
 
     cove_output = simple_func(1, 2, 3)
     expected = [
         {
-            "Id": "123123123123",
-            "Arn": "hello-arn",
-            "Email": "email@address.com",
-            "Name": "an-account-name",
+            "Id": org_accounts[1]["Id"],
+            "Arn": org_accounts[1]["Arn"],
+            "Email": org_accounts[1]["Email"],
+            "Name": org_accounts[1]["Name"],
             "Status": "ACTIVE",
             "AssumeRoleSuccess": True,
             "Result": 6,
@@ -113,13 +97,12 @@ def test_decorated_simple_func_passed_args(mock_boto3_session: MagicMock) -> Non
     assert cove_output["Results"] == expected
 
 
-def test_decorated_simple_func_passed_session_name(
-    mock_boto3_session: MagicMock,
-) -> None:
+@pytest.mark.usefixtures("org_accounts")
+def test_decorated_simple_func_passed_session_name(mock_session: Session) -> None:
     session_name = "testSessionName"
 
     @cove(
-        assuming_session=mock_boto3_session,
+        assuming_session=mock_session,
         role_session_name=session_name,
         org_master=False,
     )
@@ -132,11 +115,12 @@ def test_decorated_simple_func_passed_session_name(
     assert all(x["Result"] == session_name for x in cove_output["Results"])
 
 
-def test_decorated_simple_func_passed_policy(mock_boto3_session: MagicMock) -> None:
+@pytest.mark.usefixtures("org_accounts")
+def test_decorated_simple_func_passed_policy(mock_session: Session) -> None:
     session_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"*","Resource":"*"}]}'  # noqa: E501
 
     @cove(
-        assuming_session=mock_boto3_session,
+        assuming_session=mock_session,
         policy=session_policy,
         org_master=False,
     )
@@ -149,11 +133,12 @@ def test_decorated_simple_func_passed_policy(mock_boto3_session: MagicMock) -> N
     assert all(x["Result"] == session_policy for x in cove_output["Results"])
 
 
-def test_decorated_simple_func_passed_policy_arn(mock_boto3_session: MagicMock) -> None:
+@pytest.mark.usefixtures("org_accounts")
+def test_decorated_simple_func_passed_policy_arn(mock_session: Session) -> None:
     session_policy_arns = ["arn:aws:iam::aws:policy/IAMReadOnlyAccess"]
 
     @cove(
-        assuming_session=mock_boto3_session,
+        assuming_session=mock_session,
         policy_arns=session_policy_arns,
         org_master=False,
     )

--- a/tests/test_decorator_no_args.py
+++ b/tests/test_decorator_no_args.py
@@ -17,7 +17,6 @@ def org_accounts(mock_session: Session) -> List[AccountTypeDef]:
     return org.list_accounts()["Accounts"]
 
 
-@pytest.mark.usefixtures("mock_session")
 def test_decorated_simple_func(org_accounts: List[AccountTypeDef]) -> None:
     @cove
     def simple_func(session: CoveSession) -> str:
@@ -40,7 +39,6 @@ def test_decorated_simple_func(org_accounts: List[AccountTypeDef]) -> None:
     assert cove_output["Results"] == expected
 
 
-@pytest.mark.usefixtures("mock_session")
 def test_decorated_func_passed_arg(org_accounts: List[AccountTypeDef]) -> None:
     @cove
     def simple_func(session: CoveSession, output: str) -> str:
@@ -63,7 +61,6 @@ def test_decorated_func_passed_arg(org_accounts: List[AccountTypeDef]) -> None:
     assert cove_output["Results"] == expected
 
 
-@pytest.mark.usefixtures("mock_session")
 def test_decorated_func_passed_arg_and_kwarg(
     org_accounts: List[AccountTypeDef],
 ) -> None:

--- a/tests/test_decorator_no_args.py
+++ b/tests/test_decorator_no_args.py
@@ -17,6 +17,7 @@ def org_accounts(mock_session: Session) -> List[AccountTypeDef]:
     return org.list_accounts()["Accounts"]
 
 
+@pytest.mark.usefixtures("mock_session")
 def test_decorated_simple_func(org_accounts: List[AccountTypeDef]) -> None:
     @cove
     def simple_func(session: CoveSession) -> str:
@@ -39,6 +40,7 @@ def test_decorated_simple_func(org_accounts: List[AccountTypeDef]) -> None:
     assert cove_output["Results"] == expected
 
 
+@pytest.mark.usefixtures("mock_session")
 def test_decorated_func_passed_arg(org_accounts: List[AccountTypeDef]) -> None:
     @cove
     def simple_func(session: CoveSession, output: str) -> str:
@@ -61,6 +63,7 @@ def test_decorated_func_passed_arg(org_accounts: List[AccountTypeDef]) -> None:
     assert cove_output["Results"] == expected
 
 
+@pytest.mark.usefixtures("mock_session")
 def test_decorated_func_passed_arg_and_kwarg(
     org_accounts: List[AccountTypeDef],
 ) -> None:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,60 +1,31 @@
-from datetime import datetime
-from unittest.mock import MagicMock
+from typing import List
 
 import pytest
+from boto3 import Session
+from mypy_boto3_organizations.type_defs import AccountTypeDef
 
 from botocove import cove
 from botocove.cove_session import CoveSession
 
 
 @pytest.fixture()
-def mock_boto3_session() -> MagicMock:
-    mock_session = MagicMock()
-    list_accounts_result = {
-        "Accounts": [
-            {"Id": "123123123123", "Status": "ACTIVE"},
-            {"Id": "123123123123", "Status": "ACTIVE"},
-        ]
-    }
-    mock_session.client.return_value.get_paginator.return_value.paginate.return_value.build_full_result.return_value = (  # noqa E501
-        list_accounts_result
-    )
-    describe_account_results = [
-        {
-            "Account": {
-                "Id": "123123123123",
-                "Arn": "hello-arn",
-                "Email": "email@address.com",
-                "Name": "an-account-name",
-                "Status": "ACTIVE",
-                "JoinedMethod": "CREATED",
-                "JoinedTimestamp": datetime(2015, 1, 1),
-            }
-        },
-        {
-            "Account": {
-                "Id": "456456456456",
-                "Arn": "hello-arn",
-                "Email": "email@address.com",
-                "Name": "an-account-name",
-                "Status": "ACTIVE",
-                "JoinedMethod": "CREATED",
-                "JoinedTimestamp": datetime(2015, 1, 1),
-            }
-        },
-    ]
-    mock_session.client.return_value.describe_account.side_effect = (
-        describe_account_results
-    )
-    # Mock out the credential requiring API call
-    return mock_session
+def org_accounts(mock_session: Session) -> List[AccountTypeDef]:
+    """Returns a list of the accounts in the mock org. Index 0 is the management
+    account."""
+    org = mock_session.client("organizations")
+    org.create_organization(FeatureSet="ALL")
+    org.create_account(Email="email@address.com", AccountName="an-account-name")
+    org.create_account(Email="email@address.com", AccountName="an-account-name")
+    return org.list_accounts()["Accounts"]
 
 
-def test_no_account_id_exception(mock_boto3_session: MagicMock) -> None:
+def test_no_account_id_exception(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
     @cove(
-        assuming_session=mock_boto3_session,
-        target_ids=["456456456456"],
-        ignore_ids=["456456456456"],
+        assuming_session=mock_session,
+        target_ids=[org_accounts[1]["Id"]],
+        ignore_ids=[org_accounts[1]["Id"]],
     )
     def simple_func(session: CoveSession) -> str:
         return "hello"
@@ -66,19 +37,21 @@ def test_no_account_id_exception(mock_boto3_session: MagicMock) -> None:
         simple_func()
 
 
-def test_handled_exception_in_wrapped_func(mock_boto3_session: MagicMock) -> None:
-    @cove(assuming_session=mock_boto3_session, target_ids=["456456456456"])
+def test_handled_exception_in_wrapped_func(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
+    @cove(assuming_session=mock_session, target_ids=[org_accounts[1]["Id"]])
     def simple_func(session: CoveSession) -> None:
         raise Exception("oh no")
 
     results = simple_func()
     expected = {
-        "Id": "456456456456",
+        "Id": org_accounts[1]["Id"],
         "RoleName": "OrganizationAccountAccessRole",
         "AssumeRoleSuccess": True,
-        "Arn": "hello-arn",
-        "Email": "email@address.com",
-        "Name": "an-account-name",
+        "Arn": org_accounts[1]["Arn"],
+        "Email": org_accounts[1]["Email"],
+        "Name": org_accounts[1]["Name"],
         "Status": "ACTIVE",
         "RoleSessionName": "OrganizationAccountAccessRole",
         "ExceptionDetails": repr(Exception("oh no")),
@@ -92,10 +65,12 @@ def test_handled_exception_in_wrapped_func(mock_boto3_session: MagicMock) -> Non
     assert results["Exceptions"][0] == expected
 
 
-def test_raised_exception_in_wrapped_func(mock_boto3_session: MagicMock) -> None:
+def test_raised_exception_in_wrapped_func(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
     @cove(
-        assuming_session=mock_boto3_session,
-        target_ids=["456456456456"],
+        assuming_session=mock_session,
+        target_ids=[org_accounts[1]["Id"]],
         raise_exception=True,
     )
     def simple_func(session: CoveSession) -> None:
@@ -105,10 +80,12 @@ def test_raised_exception_in_wrapped_func(mock_boto3_session: MagicMock) -> None
         simple_func()
 
 
-def test_malformed_ignore_ids(mock_boto3_session: MagicMock) -> None:
+def test_malformed_ignore_ids(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
     @cove(
-        assuming_session=mock_boto3_session,
-        target_ids=["456456456456"],
+        assuming_session=mock_session,
+        target_ids=[org_accounts[1]["Id"]],
         ignore_ids=["cat"],
     )
     def simple_func(session: CoveSession) -> str:
@@ -121,9 +98,10 @@ def test_malformed_ignore_ids(mock_boto3_session: MagicMock) -> None:
         simple_func()
 
 
-def test_malformed_ignore_ids_type(mock_boto3_session: MagicMock) -> None:
+@pytest.mark.usefixtures("org_accounts")
+def test_malformed_ignore_ids_type(mock_session: Session) -> None:
     @cove(
-        assuming_session=mock_boto3_session,
+        assuming_session=mock_session,
         target_ids=None,
         ignore_ids=[456456456456],  # type: ignore
     )
@@ -139,11 +117,13 @@ def test_malformed_ignore_ids_type(mock_boto3_session: MagicMock) -> None:
         simple_func()
 
 
-def test_malformed_target_id(mock_boto3_session: MagicMock) -> None:
+def test_malformed_target_id(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
     @cove(
-        assuming_session=mock_boto3_session,
+        assuming_session=mock_session,
         target_ids=["xu-gzxu-393a2l5b"],
-        ignore_ids=["456456456456"],
+        ignore_ids=[org_accounts[1]["Id"]],
     )
     def simple_func(session: CoveSession) -> str:
         return "hello"
@@ -155,9 +135,9 @@ def test_malformed_target_id(mock_boto3_session: MagicMock) -> None:
         simple_func()
 
 
-def test_malformed_target_id_type(mock_boto3_session: MagicMock) -> None:
+def test_malformed_target_id_type(mock_session: Session) -> None:
     @cove(
-        assuming_session=mock_boto3_session,
+        assuming_session=mock_session,
         target_ids=[456456456456],  # type: ignore
         ignore_ids=[],
     )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -98,8 +98,9 @@ def test_malformed_ignore_ids(
         simple_func()
 
 
-@pytest.mark.usefixtures("org_accounts")
-def test_malformed_ignore_ids_type(mock_session: Session) -> None:
+def test_malformed_ignore_ids_type(
+    mock_session: Session, org_accounts: List[AccountTypeDef]
+) -> None:
     @cove(
         assuming_session=mock_session,
         target_ids=None,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,11 +1,12 @@
 from datetime import datetime
-from typing import List, cast
+from typing import List
 from unittest.mock import MagicMock
 
 import pytest
 from boto3 import Session
 from botocore.exceptions import ClientError
 from mypy_boto3_organizations.type_defs import AccountTypeDef
+from mypy_boto3_sts.type_defs import PolicyDescriptorTypeTypeDef
 from pytest_mock import MockerFixture
 
 from botocove import CoveSession, cove
@@ -102,9 +103,9 @@ def test_session_result_formatter_with_policy(
 def test_session_result_formatter_with_policy_arn(
     org_accounts: List[AccountTypeDef],
 ) -> None:
-    session_policy_arns = cast(
-        List[str], [{"arn": "arn:aws:iam::aws:policy/IAMReadOnlyAccess"}]
-    )
+    session_policy_arns: List[PolicyDescriptorTypeTypeDef] = [
+        {"arn": "arn:aws:iam::aws:policy/IAMReadOnlyAccess"}
+    ]
 
     @cove(policy_arns=session_policy_arns)
     def simple_func(session: CoveSession, a_string: str) -> str:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -20,7 +20,6 @@ def org_accounts(mock_session: Session) -> List[AccountTypeDef]:
     return org.list_accounts()["Accounts"]
 
 
-@pytest.mark.usefixtures("mock_session")
 def test_session_result_formatter(org_accounts: List[AccountTypeDef]) -> None:
     @cove
     def simple_func(session: CoveSession, a_string: str) -> str:
@@ -44,7 +43,6 @@ def test_session_result_formatter(org_accounts: List[AccountTypeDef]) -> None:
     assert cove_output["Results"] == expected
 
 
-@pytest.mark.usefixtures("mock_session")
 def test_session_result_formatter_with_policy(
     org_accounts: List[AccountTypeDef],
 ) -> None:
@@ -73,7 +71,6 @@ def test_session_result_formatter_with_policy(
     assert cove_output["Results"] == expected
 
 
-@pytest.mark.usefixtures("mock_session")
 def test_session_result_formatter_with_policy_arn(
     org_accounts: List[AccountTypeDef],
 ) -> None:
@@ -104,7 +101,6 @@ def test_session_result_formatter_with_policy_arn(
     assert cove_output["Results"] == expected
 
 
-@pytest.mark.usefixtures("mock_session")
 def test_session_result_error_handler(
     org_accounts: List[AccountTypeDef], mocker: MockerFixture
 ) -> None:


### PR DESCRIPTION
Now that we depend on moto to test organizational unit filtering (#30), we have the opportunity to refactor the other tests.

Some of the older tests are quite brittle. The mocking with MagicMock works only when the APIs are called in a certain way. In a way, these tests are coupled to a specific implementation.

Moto instead mocks the whole service, so we can load the test data using APIs in the fixture and then in the implementation we are free to call any APIs we like to get the desired result.

This is necessary to give us freedom to explore different ways of retrieving account attributes as described in #35.

Subjectively, I think it makes the test code neater as well.

I'll mark the PR as a draft until I update all the unit tests.

As always, I welcome your feedback on these changes :-)