### PR TITLE
Make the progress bar smoother

### DIFF
--- a/botocove/cove_runner.py
+++ b/botocove/cove_runner.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 
 from botocove.cove_host_account import CoveHostAccount
 from botocove.cove_session import CoveSession
-from botocove.cove_types import CoveFunctionOutput, CoveResults, CoveSessionInformation
+from botocove.cove_types import CoveFunctionOutput, CoveSessionInformation
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ class CoveRunner(object):
         # https://superfastpython.com/threadpoolexecutor-in-python/#Submit_and_Use_as_Completed
         with ThreadPoolExecutor(max_workers=self.thread_workers) as executor:
             futures = [executor.submit(self.cove_thread, s) for s in self.sessions]
-            completed: CoveResults = list(
+            completed: List[CoveSessionInformation] = list(
                 tqdm(
                     _iterate_results_in_order_of_completion(futures),
                     total=len(self.sessions),

--- a/botocove/cove_runner.py
+++ b/botocove/cove_runner.py
@@ -38,7 +38,9 @@ class CoveRunner(object):
         # "ThreadPoolExecutor in Python: The Complete Guide".
         # https://superfastpython.com/threadpoolexecutor-in-python/#Submit_and_Use_as_Completed
         with ThreadPoolExecutor(max_workers=self.thread_workers) as executor:
-            futures = [executor.submit(self.cove_thread, s) for s in self.sessions]
+            futures: List["Future[CoveSessionInformation]"] = [
+                executor.submit(self.cove_thread, s) for s in self.sessions
+            ]
             completed: List[CoveSessionInformation] = list(
                 tqdm(
                     _iterate_results_in_order_of_completion(futures),

--- a/botocove/cove_types.py
+++ b/botocove/cove_types.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Future
 from typing import Any, Dict, List, Optional, TypedDict
 
 from mypy_boto3_organizations.literals import AccountStatusType
@@ -21,6 +22,7 @@ class CoveSessionInformation(TypedDict):
 
 
 CoveResults = List[CoveSessionInformation]
+FutureCoveResults = List["Future[CoveSessionInformation]"]
 
 
 class CoveFunctionOutput(TypedDict):

--- a/botocove/cove_types.py
+++ b/botocove/cove_types.py
@@ -20,12 +20,9 @@ class CoveSessionInformation(TypedDict):
     Region: Optional[str]
 
 
-CoveResults = List[CoveSessionInformation]
-
-
 class CoveFunctionOutput(TypedDict):
-    Results: CoveResults
-    Exceptions: CoveResults
+    Results: List[CoveSessionInformation]
+    Exceptions: List[CoveSessionInformation]
 
 
 class CoveOutput(TypedDict):

--- a/botocove/cove_types.py
+++ b/botocove/cove_types.py
@@ -1,4 +1,3 @@
-from concurrent.futures import Future
 from typing import Any, Dict, List, Optional, TypedDict
 
 from mypy_boto3_organizations.literals import AccountStatusType
@@ -22,7 +21,6 @@ class CoveSessionInformation(TypedDict):
 
 
 CoveResults = List[CoveSessionInformation]
-FutureCoveResults = List["Future[CoveSessionInformation]"]
 
 
 class CoveFunctionOutput(TypedDict):


### PR DESCRIPTION
Use the "Submit and use as completed" pattern as described by Jason Brownlee in
"ThreadPoolExecutor in Python: The Complete Guide".

Fixes #37