### PR TITLE
Keep AccountTypeDef to avoid DescribeAccount calls

### DIFF
--- a/botocove/cove_session.py
+++ b/botocove/cove_session.py
@@ -4,7 +4,6 @@ from typing import Any
 from boto3.session import Session
 from botocore.exceptions import ClientError
 from mypy_boto3_organizations.client import OrganizationsClient
-from mypy_boto3_organizations.type_defs import AccountTypeDef
 from mypy_boto3_sts.client import STSClient
 
 from botocove.cove_types import CoveSessionInformation
@@ -43,21 +42,6 @@ class CoveSession(Session):
             f"arn:aws:iam::{self.session_information['Id']}:role/"
             f"{self.session_information['RoleName']}"
         )
-
-        if self.org_master:
-            try:
-                account_description: AccountTypeDef = self.org_client.describe_account(
-                    AccountId=self.session_information["Id"]
-                )["Account"]
-                self.session_information["Arn"] = account_description["Arn"]
-                self.session_information["Email"] = account_description["Email"]
-                self.session_information["Name"] = account_description["Name"]
-                self.session_information["Status"] = account_description["Status"]
-            except ClientError:
-                logger.exception(
-                    "Failed to call describe_account for "
-                    f"{self.session_information['Id']}"
-                )
 
         try:
             logger.debug(f"Attempting to assume {role_arn}")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,11 +1,9 @@
-from typing import Any, List
+from typing import List
 
 import pytest
 from boto3 import Session
-from botocore.exceptions import ClientError
 from mypy_boto3_organizations.type_defs import AccountTypeDef
 from mypy_boto3_sts.type_defs import PolicyDescriptorTypeTypeDef
-from pytest_mock import MockerFixture
 
 from botocove import CoveSession, cove
 
@@ -96,36 +94,6 @@ def test_session_result_formatter_with_policy_arn(
             "RoleName": "OrganizationAccountAccessRole",
             "RoleSessionName": "OrganizationAccountAccessRole",
             "PolicyArns": session_policy_arns,
-        }
-    ]
-    assert cove_output["Results"] == expected
-
-
-def test_session_result_error_handler(
-    org_accounts: List[AccountTypeDef], mocker: MockerFixture
-) -> None:
-    def describe_account(*args: Any, **kwargs: Any) -> None:
-        raise ClientError(
-            {"Error": {"Message": "broken!", "Code": "OhNo"}}, "describe_account"
-        )
-
-    mocker.patch(
-        "moto.organizations.models.OrganizationsBackend.describe_account",
-        describe_account,
-    )
-
-    @cove()
-    def simple_func(session: CoveSession, a_string: str) -> str:
-        return a_string
-
-    cove_output = simple_func("test-string")
-    expected = [
-        {
-            "Id": org_accounts[1]["Id"],
-            "AssumeRoleSuccess": True,
-            "Result": "test-string",
-            "RoleName": "OrganizationAccountAccessRole",
-            "RoleSessionName": "OrganizationAccountAccessRole",
         }
     ]
     assert cove_output["Results"] == expected


### PR DESCRIPTION

In this design I haven't eliminated the use of DescribeAccount completely. It may still be needed to fill in the details for IDs captured via target_ids. But now all the organizations API calls are in the CoveHostAccount class, where they make most sense, and the active_cove_session function concerns itself only with assuming the role in the target account.

I've marked this as a draft because there's two things I'm unhappy with.

It seems to have introduced a memory leak. I may need to dig out the old test code from #20 to confirm that with more rigor.

The change of the internal structure from a list of IDs to a dict of IDs to AccountTypeDefs means the elegant hack used in #37 to repeat a single target account to simulate a big org doesn't work any more. I think the testing in #20 used the same technique, so I'll need to find another way to support that.

Any thoughts on how to solve these problems?