### PR TITLE
Keep AccountTypeDef to avoid DescribeAccount calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ arguments to understand safe experimentation with this package.
 
 ## Pre-requisites and Info
 
-An IAM user with `sts:assumerole` privilege, and accounts that have a trust
+An IAM user with `sts:AssumeRole` privilege, and accounts that have a trust
 relationship to the IAM user's account.
 
 By default, the IAM user is expected to be in an AWS Organization Master
@@ -37,10 +37,12 @@ Cove will not execute a function call in the account it's called from.
 
 Default requirements are:
 
-In the organization master account:
+In the organization master account, an identity with at least these permissions:
 
-- IAM permissions `sts:assumerole`, `sts:get-caller-identity` and
-`organizations:list-accounts`
+- `sts:AssumeRole`
+- `organizations:ListAccounts`
+- `organizations:ListOrganizationalUnitsForParent`
+- `organizations:ListAccountsForParent`
 
 In the organization member accounts:
 

--- a/botocove/cove_decorator.py
+++ b/botocove/cove_decorator.py
@@ -31,8 +31,8 @@ def cove(
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> CoveOutput:
 
-            _validate_ids(target_ids)
-            _validate_ids(ignore_ids)
+            _typecheck_id_list(target_ids)
+            _typecheck_id_list(ignore_ids)
 
             host_account = CoveHostAccount(
                 target_ids=target_ids,
@@ -85,15 +85,17 @@ def cove(
         return decorator(_func)
 
 
-def _validate_ids(ids: Optional[List[str]]) -> None:
-    if ids is None:
+def _typecheck_id_list(list_of_ids: Optional[List[str]]) -> None:
+    if list_of_ids is None:
         return
+    for _id in list_of_ids:
+        _typecheck_id(_id)
 
-    for _id in ids:
-        if isinstance(_id, str):
-            continue
 
-        raise TypeError(
-            f"{_id} is an incorrect type: all account and ou id's must be strings "
-            f"not {type(_id)}"
-        )
+def _typecheck_id(_id: str) -> None:
+    if isinstance(_id, str):
+        return
+    raise TypeError(
+        f"{_id} is an incorrect type: all account and ou id's must be strings "
+        f"not {type(_id)}"
+    )

--- a/botocove/cove_decorator.py
+++ b/botocove/cove_decorator.py
@@ -25,11 +25,14 @@ def cove(
     raise_exception: bool = False,
     org_master: bool = True,
     thread_workers: int = 20,
-    regions: Optional[List[str]] = None
+    regions: Optional[List[str]] = None,
 ) -> Callable:
     def decorator(func: Callable[..., Any]) -> Callable[..., CoveOutput]:
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> CoveOutput:
+
+            _validate_ids(target_ids)
+            _validate_ids(ignore_ids)
 
             host_account = CoveHostAccount(
                 target_ids=target_ids,
@@ -80,3 +83,17 @@ def cove(
         return decorator
     else:
         return decorator(_func)
+
+
+def _validate_ids(ids: Optional[List[str]]) -> None:
+    if ids is None:
+        return
+
+    for _id in ids:
+        if isinstance(_id, str):
+            continue
+
+        raise TypeError(
+            f"{_id} is an incorrect type: all account and ou id's must be strings "
+            f"not {type(_id)}"
+        )

--- a/botocove/cove_host_account.py
+++ b/botocove/cove_host_account.py
@@ -124,13 +124,9 @@ def _host_account_is_in_organization(client: OrganizationsClient) -> bool:
         client.describe_organization()
         return True
     except ClientError as error:
-        if _organizations_service_not_in_use(error):
+        if error.response["Error"]["Code"] == "AWSOrganizationsNotInUseException":
             return False
         raise error
-
-
-def _organizations_service_not_in_use(error: ClientError) -> bool:
-    return error.response["Error"]["Code"] == "AWSOrganizationsNotInUseException"
 
 
 def _resolve_target_accounts(

--- a/botocove/cove_runner.py
+++ b/botocove/cove_runner.py
@@ -67,8 +67,6 @@ class CoveRunner(object):
         cove_session = CoveSession(
             account_session_info,
             sts_client=self.host_account.sts_client,
-            org_client=self.host_account.org_client,
-            org_master=self.host_account.org_master,
         )
         try:
             cove_session.activate_cove_session()

--- a/botocove/cove_session.py
+++ b/botocove/cove_session.py
@@ -3,8 +3,6 @@ from typing import Any
 
 from boto3.session import Session
 from botocore.exceptions import ClientError
-from mypy_boto3_organizations.client import OrganizationsClient
-from mypy_boto3_organizations.type_defs import AccountTypeDef
 from mypy_boto3_sts.client import STSClient
 
 from botocove.cove_types import CoveSessionInformation
@@ -25,13 +23,9 @@ class CoveSession(Session):
     def __init__(
         self,
         session_info: CoveSessionInformation,
-        org_client: OrganizationsClient,
         sts_client: STSClient,
-        org_master: bool,
     ) -> None:
         self.session_information = session_info
-        self.org_master = org_master
-        self.org_client = org_client
         self.sts_client = sts_client
 
     def __repr__(self) -> str:
@@ -43,21 +37,6 @@ class CoveSession(Session):
             f"arn:aws:iam::{self.session_information['Id']}:role/"
             f"{self.session_information['RoleName']}"
         )
-
-        if self.org_master:
-            try:
-                account_description: AccountTypeDef = self.org_client.describe_account(
-                    AccountId=self.session_information["Id"]
-                )["Account"]
-                self.session_information["Arn"] = account_description["Arn"]
-                self.session_information["Email"] = account_description["Email"]
-                self.session_information["Name"] = account_description["Name"]
-                self.session_information["Status"] = account_description["Status"]
-            except ClientError:
-                logger.exception(
-                    "Failed to call describe_account for "
-                    f"{self.session_information['Id']}"
-                )
 
         try:
             logger.debug(f"Attempting to assume {role_arn}")

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -1,0 +1,61 @@
+# test_new.py - I don't know what to call this yet.
+import pytest
+from boto3.session import Session
+
+from botocove import cove
+
+
+def test_when_org_not_used_and_has_target_account_then_output_has_id_key(
+    mock_session: Session,
+) -> None:
+    @cove(target_ids=["111111111111"])
+    def do_nothing(session: Session) -> None:
+        pass
+
+    output = do_nothing()
+
+    result_ids = [r["Id"] for r in output["Results"]]
+    assert result_ids == ["111111111111"]
+
+
+def test_when_org_not_used_and_target_account_passed_then_output_has_no_org_metadata(
+    mock_session: Session,
+) -> None:
+    @cove(target_ids=["111111111111"])
+    def do_nothing(session: Session) -> None:
+        pass
+
+    output = do_nothing()
+
+    org_metadata_keys = {"Name", "Arn", "Email", "Status", "JoinedDate"}
+    assert output["Results"]
+    for r in output["Results"]:
+        for k in r:
+            assert k not in org_metadata_keys
+
+
+def test_when_org_not_used_and_has_no_target_then_raise_value_error(
+    mock_session: Session,
+) -> None:
+    @cove()
+    def do_nothing(session: Session) -> None:
+        pass
+
+    with pytest.raises(
+        ValueError,
+        match="There are no eligible account ids to run decorated func against",
+    ):
+        do_nothing()
+
+
+def test_when_org_not_used_and_has_target_ou_then_raise_value_error(
+    mock_session: Session,
+) -> None:
+    @cove(target_ids=["ou-aaaa-aaaaaaaa"])
+    def do_nothing(session: Session) -> None:
+        pass
+
+    with pytest.raises(
+        ValueError, match="provided id is not an aws account: ou-aaaa-aaaaaaaa"
+    ):
+        do_nothing()

--- a/tests/test_org_master_deprecation.py
+++ b/tests/test_org_master_deprecation.py
@@ -1,0 +1,52 @@
+# Good intro to depreaction here: https://dev.to/hckjck/python-deprecation-2mof
+# Python documentation: https://docs.python.org/3/library/warnings.html#testing-warnings
+
+import warnings
+
+import pytest
+from boto3.session import Session
+
+from botocove import cove
+from tests.moto_mock_org.moto_models import SmallOrg
+
+
+def test_when_org_master_is_unset_then_do_not_warn(mock_small_org: SmallOrg) -> None:
+    @cove()
+    def do_nothing(session: Session) -> None:
+        pass
+
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("error")
+        do_nothing()
+
+
+@pytest.mark.parametrize("org_master", [True, False])
+def test_when_org_master_is_set_then_warn(
+    org_master: bool, mock_small_org: SmallOrg
+) -> None:
+    @cove(org_master=org_master)
+    def do_nothing(session: Session) -> None:
+        pass
+
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("error")
+
+        with pytest.raises(
+            DeprecationWarning,
+            match="Don't set org_master. cove behaves as if it were True",
+        ):
+
+            do_nothing()
+
+
+def test_when_unexpected_kwarg_passed_then_raises_type_error(
+    mock_small_org: SmallOrg,
+) -> None:
+    @cove(fake_arg="fake_value")
+    def do_nothing(session: Session) -> None:
+        pass
+
+    with pytest.raises(
+        TypeError, match=r"cove\(\) got an unexpected keyword argument 'fake_arg'"
+    ):
+        do_nothing()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,11 +1,9 @@
-from typing import Any, List
+from typing import List
 
 import pytest
 from boto3 import Session
-from botocore.exceptions import ClientError
 from mypy_boto3_organizations.type_defs import AccountTypeDef
 from mypy_boto3_sts.type_defs import PolicyDescriptorTypeTypeDef
-from pytest_mock import MockerFixture
 
 from botocove import CoveSession, cove
 
@@ -96,36 +94,6 @@ def test_session_result_formatter_with_policy_arn(
             "RoleName": "OrganizationAccountAccessRole",
             "RoleSessionName": "OrganizationAccountAccessRole",
             "PolicyArns": session_policy_arns,
-        }
-    ]
-    assert cove_output["Results"] == expected
-
-
-def test_session_result_error_handler(
-    org_accounts: List[AccountTypeDef], mocker: MockerFixture
-) -> None:
-    def describe_account(*args: Any, **kwargs: Any) -> None:
-        raise ClientError(
-            {"Error": {"Message": "broken!", "Code": "OhNo"}}, "describe_account"
-        )
-
-    mocker.patch(
-        "moto.organizations.models.OrganizationsBackend.describe_account",
-        describe_account,
-    )
-
-    @cove()
-    def simple_func(session: CoveSession, a_string: str) -> str:
-        return a_string
-
-    cove_output = simple_func("test-string")
-    expected = [
-        {
-            "Id": org_accounts[1]["Id"],
-            "AssumeRoleSuccess": True,
-            "Result": "test-string",
-            "RoleName": "OrganizationAccountAccessRole",
-            "RoleSessionName": "OrganizationAccountAccessRole",
         }
     ]
     assert cove_output["Results"] == expected


### PR DESCRIPTION
This design improves upon my attempt in #39 because it eliminates the DescribeAccount calls completely.