### PR TITLE
Revert to consistent date for changelog 1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.6.4] - 2022-11-28
+## [1.6.4] - 2022-28-11
 
 ### Added
 


### PR DESCRIPTION
All other changelog dates use YYYY-DD-MM format.

This reverts commit 8743861eee0586951da95d59495c28748b837164.

There I changed the date format to YYYY-MM-DD without understanding that YYYY-DD-MM had been used consistently before.