### PR TITLE
Improve error handling for target_ids

### DIFF
--- a/botocove/cove_decorator.py
+++ b/botocove/cove_decorator.py
@@ -122,7 +122,7 @@ def _check_deprecation(kwargs: Dict[str, Any]) -> None:
 def _raise_type_error_for_any_kwarg_except_org_master(kwargs: Dict[str, Any]) -> None:
     for key in kwargs:
         if key != "org_master":
-            raise TypeError(f"Cove() got an unexpected keyword argument '{key}'")
+            raise TypeError(f"cove() got an unexpected keyword argument '{key}'")
     return None
 
 

--- a/botocove/cove_decorator.py
+++ b/botocove/cove_decorator.py
@@ -37,8 +37,8 @@ def cove(
 
             _typecheck_regions(regions)
             _typecheck_external_id(external_id)
-            _typecheck_id_list(target_ids, "target_ids")
-            _typecheck_id_list(ignore_ids, "ignore_ids")
+            _typecheck_target_ids(target_ids)
+            _typecheck_ignore_ids(ignore_ids)
 
             host_account = CoveHostAccount(
                 target_ids=target_ids,
@@ -126,11 +126,26 @@ def _raise_type_error_for_any_kwarg_except_org_master(kwargs: Dict[str, Any]) ->
     return None
 
 
-def _typecheck_id_list(list_of_ids: Optional[List[str]], name: str) -> None:
+def _typecheck_target_ids(list_of_ids: Optional[List[str]]) -> None:
     if list_of_ids is None:
         return
     if isinstance(list_of_ids, str):
-        raise TypeError(f"{name} must be a list of str. Got str {repr(list_of_ids)}.")
+        raise TypeError(
+            f"target_ids must be a list of str. Got str {repr(list_of_ids)}."
+        )
+    if len(list_of_ids) == 0:
+        raise ValueError("target_ids when specified must have at least 1 element.")
+    for _id in list_of_ids:
+        _typecheck_id(_id)
+
+
+def _typecheck_ignore_ids(list_of_ids: Optional[List[str]]) -> None:
+    if list_of_ids is None:
+        return
+    if isinstance(list_of_ids, str):
+        raise TypeError(
+            f"ignore_ids must be a list of str. Got str {repr(list_of_ids)}."
+        )
     for _id in list_of_ids:
         _typecheck_id(_id)
 

--- a/botocove/cove_decorator.py
+++ b/botocove/cove_decorator.py
@@ -134,7 +134,9 @@ def _typecheck_target_ids(list_of_ids: Optional[List[str]]) -> None:
             f"target_ids must be a list of str. Got str {repr(list_of_ids)}."
         )
     if len(list_of_ids) == 0:
-        raise ValueError("target_ids when specified must have at least 1 element.")
+        raise ValueError(
+            f"target_ids must have at least 1 element. Got {repr(list_of_ids)}."
+        )
     for _id in list_of_ids:
         _typecheck_id(_id)
 

--- a/botocove/cove_decorator.py
+++ b/botocove/cove_decorator.py
@@ -98,6 +98,10 @@ def _typecheck_regions(list_of_regions: Optional[List[str]]) -> None:
         raise TypeError(
             f"regions must be a list of str. Got str {repr(list_of_regions)}."
         )
+    if len(list_of_regions) == 0:
+        raise ValueError(
+            f"regions must have at least 1 element. Got {repr(list_of_regions)}."
+        )
 
 
 def _typecheck_external_id(external_id: Optional[str]) -> None:

--- a/botocove/cove_decorator.py
+++ b/botocove/cove_decorator.py
@@ -37,8 +37,8 @@ def cove(
 
             _typecheck_regions(regions)
             _typecheck_external_id(external_id)
-            _typecheck_id_list(target_ids)
-            _typecheck_id_list(ignore_ids)
+            _typecheck_id_list(target_ids, "target_ids")
+            _typecheck_id_list(ignore_ids, "ignore_ids")
 
             host_account = CoveHostAccount(
                 target_ids=target_ids,
@@ -126,9 +126,11 @@ def _raise_type_error_for_any_kwarg_except_org_master(kwargs: Dict[str, Any]) ->
     return None
 
 
-def _typecheck_id_list(list_of_ids: Optional[List[str]]) -> None:
+def _typecheck_id_list(list_of_ids: Optional[List[str]], name: str) -> None:
     if list_of_ids is None:
         return
+    if isinstance(list_of_ids, str):
+        raise TypeError(f"{name} must be a list of str. Got str {repr(list_of_ids)}.")
     for _id in list_of_ids:
         _typecheck_id(_id)
 

--- a/botocove/cove_host_account.py
+++ b/botocove/cove_host_account.py
@@ -102,8 +102,9 @@ class CoveHostAccount(object):
             for account_id in self.target_accounts:
                 if self.account_data is not None:
 
-                    # If running with target accounts, but with organization data available
-                    # ie running from org master but not targeting whole org
+                    # If running with target accounts, but with organization data
+                    # available, i.e., running from org master but not targeting
+                    # whole org.
                     if account_id not in self.account_data:
                         raise ValueError(
                             f"Account {account_id} is not ACTIVE in the organization."

--- a/botocove/cove_host_account.py
+++ b/botocove/cove_host_account.py
@@ -102,6 +102,10 @@ class CoveHostAccount(object):
             for account_id in self.target_accounts:
                 if self.account_data is not None:
 
+                    # I think this can be true only when running in an organization
+                    # and when target_ids contains an account ID from outside
+                    # the organization. We'd like to validate this earlier, but
+                    # it's not practical without a lot of code reorganization.
                     if account_id not in self.account_data:
                         raise ValueError(
                             f"Account {account_id} is not in the organization."

--- a/botocove/cove_host_account.py
+++ b/botocove/cove_host_account.py
@@ -102,10 +102,8 @@ class CoveHostAccount(object):
             for account_id in self.target_accounts:
                 if self.account_data is not None:
 
-                    # I think this can be true only when running in an organization
-                    # and when target_ids contains an account ID from outside
-                    # the organization. We'd like to validate this earlier, but
-                    # it's not practical without a lot of code reorganization.
+                    # If running with target accounts, but with organization data available
+                    # ie running from org master but not targeting whole org
                     if account_id not in self.account_data:
                         raise ValueError(
                             f"Account {account_id} is not ACTIVE in the organization."

--- a/botocove/cove_host_account.py
+++ b/botocove/cove_host_account.py
@@ -108,7 +108,7 @@ class CoveHostAccount(object):
                     # it's not practical without a lot of code reorganization.
                     if account_id not in self.account_data:
                         raise ValueError(
-                            f"Account {account_id} is not in the organization."
+                            f"Account {account_id} is not ACTIVE in the organization."
                         )
 
                     yield CoveSessionInformation(

--- a/botocove/cove_host_account.py
+++ b/botocove/cove_host_account.py
@@ -101,6 +101,12 @@ class CoveHostAccount(object):
         for region in self.target_regions:
             for account_id in self.target_accounts:
                 if self.account_data is not None:
+
+                    if account_id not in self.account_data:
+                        raise ValueError(
+                            f"Account {account_id} is not in the organization."
+                        )
+
                     yield CoveSessionInformation(
                         Id=account_id,
                         RoleName=self.role_to_assume,

--- a/botocove/cove_host_account.py
+++ b/botocove/cove_host_account.py
@@ -194,6 +194,8 @@ class CoveHostAccount(object):
         return ignored_accounts
 
     def _gather_target_accounts(self, targets: Optional[List[str]]) -> Set[str]:
+        if targets is not None and len(targets) == 0:
+            raise ValueError("target_ids when specified must have at least 1 element.")
         if targets:
             accs, ous = self._get_validated_ids(targets)
             if ous:

--- a/botocove/cove_host_account.py
+++ b/botocove/cove_host_account.py
@@ -198,8 +198,6 @@ class CoveHostAccount(object):
         return ignored_accounts
 
     def _gather_target_accounts(self, targets: Optional[List[str]]) -> Set[str]:
-        if targets is not None and len(targets) == 0:
-            raise ValueError("target_ids when specified must have at least 1 element.")
         if targets:
             accs, ous = self._get_validated_ids(targets)
             if ous:

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -35,7 +35,7 @@ def test_when_region_is_str_then_raises_type_error(mock_small_org: SmallOrg) -> 
         pass
 
     with pytest.raises(
-        TypeError, match="regions must be a list of str. Got str 'eu-west-1'."
+        TypeError, match=r"regions must be a list of str\. Got str 'eu-west-1'\."
     ):
         do_nothing()
 

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -40,6 +40,17 @@ def test_when_region_is_str_then_raises_type_error(mock_small_org: SmallOrg) -> 
         do_nothing()
 
 
+def test_when_region_is_empty_then_raises_value_error(mock_small_org: SmallOrg) -> None:
+    @cove(regions=[])
+    def do_nothing() -> None:
+        pass
+
+    with pytest.raises(
+        ValueError, match=r"regions must have at least 1 element\. Got \[\]\."
+    ):
+        do_nothing()
+
+
 def test_when_any_region_is_passed_then_result_has_region_key(
     mock_small_org: SmallOrg,
 ) -> None:

--- a/tests/test_target_ids.py
+++ b/tests/test_target_ids.py
@@ -32,6 +32,17 @@ def test_when_accounts_in_org_then_output_has_result_for_each_target_id(
     assert set(some_org_accounts) == {r["Id"] for r in output["Results"]}
 
 
+def test_when_target_id_is_str_then_raises_type_error(mock_small_org: SmallOrg) -> None:
+    @cove(target_ids="111111111111")  # type: ignore[arg-type]
+    def do_nothing(session: Session) -> None:
+        pass
+
+    with pytest.raises(
+        TypeError, match=r"target_ids must be a list of str. Got str '111111111111'\."
+    ):
+        do_nothing()
+
+
 def test_when_account_not_in_org_raises_value_error(
     mock_small_org: SmallOrg,
 ) -> None:

--- a/tests/test_target_ids.py
+++ b/tests/test_target_ids.py
@@ -19,3 +19,16 @@ def test_when_account_not_in_org_raises_value_error(
         ValueError, match=r"Account 111111111111 is not in the organization\."
     ):
         do_nothing()
+
+
+def test_when_empty_sequence_raises_value_error(
+    mock_small_org: SmallOrg,
+) -> None:
+    @cove(target_ids=[])
+    def do_nothing(session: Session) -> None:
+        pass
+
+    with pytest.raises(
+        ValueError, match=r"target_ids when specified must have at least 1 element\."
+    ):
+        do_nothing()

--- a/tests/test_target_ids.py
+++ b/tests/test_target_ids.py
@@ -16,6 +16,22 @@ def test_when_unspecified_then_output_has_a_result_for_each_org_account(
     assert set(mock_small_org.all_accounts) == {r["Id"] for r in output["Results"]}
 
 
+def test_when_accounts_in_org_then_output_has_result_for_each_target_id(
+    mock_small_org: SmallOrg,
+) -> None:
+    some_org_accounts = [
+        mock_small_org.all_accounts[0],
+        mock_small_org.all_accounts[1],
+    ]
+
+    @cove(target_ids=some_org_accounts)
+    def do_nothing(session: Session) -> None:
+        pass
+
+    output = do_nothing()
+    assert set(some_org_accounts) == {r["Id"] for r in output["Results"]}
+
+
 def test_when_account_not_in_org_raises_value_error(
     mock_small_org: SmallOrg,
 ) -> None:

--- a/tests/test_target_ids.py
+++ b/tests/test_target_ids.py
@@ -1,0 +1,21 @@
+import pytest
+from boto3.session import Session
+
+from botocove import cove
+from tests.moto_mock_org.moto_models import SmallOrg
+
+
+def test_when_account_not_in_org_raises_value_error(
+    mock_small_org: SmallOrg,
+) -> None:
+    account_not_in_org = "111111111111"
+    assert account_not_in_org not in mock_small_org.all_accounts
+
+    @cove(target_ids=[account_not_in_org])
+    def do_nothing(session: Session) -> None:
+        pass
+
+    with pytest.raises(
+        ValueError, match=r"Account 111111111111 is not in the organization\."
+    ):
+        do_nothing()

--- a/tests/test_target_ids.py
+++ b/tests/test_target_ids.py
@@ -54,7 +54,7 @@ def test_when_account_not_in_org_raises_value_error(
         pass
 
     with pytest.raises(
-        ValueError, match=r"Account 111111111111 is not in the organization\."
+        ValueError, match=r"Account 111111111111 is not ACTIVE in the organization\."
     ):
         do_nothing()
 

--- a/tests/test_target_ids.py
+++ b/tests/test_target_ids.py
@@ -5,6 +5,17 @@ from botocove import cove
 from tests.moto_mock_org.moto_models import SmallOrg
 
 
+def test_when_unspecified_then_output_has_a_result_for_each_org_account(
+    mock_small_org: SmallOrg,
+) -> None:
+    @cove()
+    def do_nothing(session: Session) -> None:
+        pass
+
+    output = do_nothing()
+    assert set(mock_small_org.all_accounts) == {r["Id"] for r in output["Results"]}
+
+
 def test_when_account_not_in_org_raises_value_error(
     mock_small_org: SmallOrg,
 ) -> None:

--- a/tests/test_target_ids.py
+++ b/tests/test_target_ids.py
@@ -67,6 +67,6 @@ def test_when_empty_sequence_raises_value_error(
         pass
 
     with pytest.raises(
-        ValueError, match=r"target_ids when specified must have at least 1 element\."
+        ValueError, match=r"target_ids must have at least 1 element\. Got \[\]\."
     ):
         do_nothing()


### PR DESCRIPTION
I passed the account ID of an ex-account and had botocove blow up with a KeyError inside the _generate_account_sessions function.

It's good that it fails, but the user feedback could be improved.

This is my proposal for a new set of tests that checks the behavior of the target_ids.

I've just covered the case I encountered today, but there are surely more that would be good to cover.