### PR TITLE
Upgrade isort to fix CI error.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     - id: markdownlint-cli2
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
See [CI error][1]:

```text
RuntimeError: The Poetry configuration is invalid:
  - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```

See [isort issues referencing `pip-shims`](https://github.com/PyCQA/isort/issues/2083) for more details.

[1]: https://github.com/connelldave/botocove/actions/runs/4120906018/jobs/7116097629