### PR TITLE
Fail fast on invalid region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ MANIFEST
 # Unit test / coverage reports
 .coverage
 .pytest_cache/
+.flakeheaven_cache/

--- a/botocove/__init__.py
+++ b/botocove/__init__.py
@@ -1,5 +1,5 @@
 from botocove.cove_decorator import cove
 from botocove.cove_session import CoveSession
-from botocove.cove_types import CoveOutput
+from botocove.cove_types import CoveOutput, InvalidRegion
 
-__all__ = ["cove", "CoveSession", "CoveOutput"]
+__all__ = ["cove", "CoveSession", "CoveOutput", "InvalidRegion"]

--- a/botocove/cove_session.py
+++ b/botocove/cove_session.py
@@ -90,3 +90,11 @@ class CoveSession(Session):
     def format_cove_error(self, err: Exception) -> CoveSessionInformation:
         self.session_information["ExceptionDetails"] = err
         return self.session_information
+
+    def is_region_in_boto3_model(self) -> bool:
+        boto3_regions = {
+            r
+            for p in self.get_available_partitions()
+            for r in self.get_available_regions("ec2", p)
+        }
+        return self.session_information["Region"] in boto3_regions

--- a/botocove/cove_types.py
+++ b/botocove/cove_types.py
@@ -31,3 +31,13 @@ class CoveOutput(TypedDict):
     Results: List[Dict[str, Any]]
     Exceptions: List[Dict[str, Any]]
     FailedAssumeRole: List[Dict[str, Any]]
+
+
+class BotocoveError(Exception):
+    """Base class for all Botocove errors."""
+    pass
+
+class InvalidRegion(Exception):
+    """Indicates that client region input is invalid."""
+    def __init__(self, region: str) -> None:
+        self.region = region


### PR DESCRIPTION
Resolves #55 by assuming any region is valid until evidence to the contrary. If a request raises an EndpointConnectionError and the region isn't in Boto3's model, then in all liklihood, the region doesn't exist.