### PR TITLE
Use latest dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ MANIFEST
 # Unit test / coverage reports
 .coverage
 .pytest_cache/
+.flakeheaven_cache/
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,24 +16,29 @@ boto3-stubs = {extras = ["sts", "organizations"], version = "*"}
 types-tqdm = "*"
 
 [tool.poetry.dev-dependencies]
-pytest = "*"
-pytest-mock = "*"
-isort = "*"
-black = "*"
-flake8-bugbear = "*"
-flake8-builtins = "*"
-flake8-comprehensions = "*"
-flake8-eradicate = "*"
-flake8-isort = "*"
-flake8-mutable = "*"
-flake8-pytest-style = "*"
-pep8-naming = "*"
-flake8-print = "*"
-mypy = "*"
-pre-commit = "*"
-flakeheaven = "*"
-moto = {extras = ["organizations", "sts"], version = "*"}
-pytest-randomly = "*"
+
+# Latest versions on 2023-10-08.
+pytest = ">=7.4.2"
+pytest-mock = ">=3.11.1"
+isort = ">=5.12.0"
+black = ">=23.9.1"
+flake8-builtins = ">=2.1.0"
+flake8-comprehensions = ">=3.14.0"
+flake8-eradicate = ">=1.4.0"
+flake8-isort = ">=6.1.0"
+flake8-mutable = ">=1.2.0"
+flake8-pytest-style = ">=1.7.2"
+flake8-print = ">=5.0.0"
+mypy = ">=1.5.1"
+pre-commit = ">=3.4.0"
+flakeheaven = ">=3.3.0"
+moto = {extras = ["organizations", "sts"], version = ">=4.2.5"}
+pytest-randomly = ">=3.15.0"
+
+# These are the last versions compatible with flake8 4. flakeheaven 3.3.0 is
+# stuck on flake8 4. https://github.com/flakeheaven/flakeheaven/issues/132
+pep8-naming = "==0.13.2"
+flake8-bugbear = "==23.3.12"
 
 # Hint to the Poetry resolver to resolve boto3 correctly.
 # Otherwise there is a conflict with moto via requests.


### PR DESCRIPTION
Pin a minimum version for the dev dependencies to ensure sane behavior of Poetry's resolver.

Commit 8bbe6217 removed the version constraints from all dependencies in `pyproject.toml`. It's the right thing to do for the application dependencies, but it's counter-productive for the dev dependencies.

flakeheaven stopped working yesterday. Poetry selected prehistoric flakeheaven version 0.11.0. The [changelog](https://github.com/flakeheaven/flakeheaven/blob/4591fd3dd04c8180d702e5eab3ec25947d7d3393/CHANGELOG.md) stops at 0.11.1!

```console
$ poetry install
Creating virtualenv botocove-r3vy5Ybn-py3.8 in /home/isme/.cache/pypoetry/virtualenvs
Updating dependencies
Resolving dependencies... (11.0s)

Package operations: 76 installs, 0 updates, 0 removals

  ...
  • Installing flakeheaven (0.11.0)
  ...

Writing lock file

Installing the current project: botocove (1.7.3)
```

```console
$ pre-commit run flakeheaven --all-files
flakeheaven..............................................................Failed
- hook id: flakeheaven
- exit code: 1

Traceback (most recent call last):
  File "/home/isme/.cache/pypoetry/virtualenvs/botocove-r3vy5Ybn-py3.8/bin/flakeheaven", line 5, in <module>
    from flakeheaven import entrypoint
  File "/home/isme/.cache/pypoetry/virtualenvs/botocove-r3vy5Ybn-py3.8/lib/python3.8/site-packages/flakeheaven/__init__.py", line 5, in <module>
    from ._cli import entrypoint, flake8_entrypoint
  File "/home/isme/.cache/pypoetry/virtualenvs/botocove-r3vy5Ybn-py3.8/lib/python3.8/site-packages/flakeheaven/_cli.py", line 9, in <module>
    from .commands import COMMANDS
  File "/home/isme/.cache/pypoetry/virtualenvs/botocove-r3vy5Ybn-py3.8/lib/python3.8/site-packages/flakeheaven/commands/__init__.py", line 5, in <module>
    from ._baseline import baseline_command
  File "/home/isme/.cache/pypoetry/virtualenvs/botocove-r3vy5Ybn-py3.8/lib/python3.8/site-packages/flakeheaven/commands/_baseline.py", line 6, in <module>
    from .._patched import FlakeHeavenApplication
  File "/home/isme/.cache/pypoetry/virtualenvs/botocove-r3vy5Ybn-py3.8/lib/python3.8/site-packages/flakeheaven/_patched/__init__.py", line 2, in <module>
    from ._app import FlakeHeavenApplication
  File "/home/isme/.cache/pypoetry/virtualenvs/botocove-r3vy5Ybn-py3.8/lib/python3.8/site-packages/flakeheaven/_patched/_app.py", line 10, in <module>
    from flake8.options.config import ConfigParser, get_local_plugins
ImportError: cannot import name 'ConfigParser' from 'flake8.options.config' (/home/isme/.cache/pypoetry/virtualenvs/botocove-r3vy5Ybn-py3.8/lib/python3.8/site-packages/flake8/options/config.py)
```

The latest CI run ([#73](https://github.com/iainelder/botocove/actions/runs/6443200026/job/17494862297#logs)) in my project fork started at 2023-10-07T20:06Z. That run installed flakeheaven 3.3.0 and the pre-commit check passed.

> Install dev packages
>
> ```text
>   • Installing flakeheaven (3.3.0)
> ```
>
> Lint with flakeheaven
>
> ```text
> flakeheaven..............................................................Passed
> ```